### PR TITLE
Add Laravel requisition management example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## PHP Backend
+
+The `laravel` directory contains an example Laravel + Filament application implementing a requisition management system. It shows how purchase requests can be submitted and approved with a simple workflow. See `laravel/README.md` for setup instructions.
+

--- a/laravel/README.md
+++ b/laravel/README.md
@@ -1,0 +1,17 @@
+# Laravel Filament Requisition Management System
+
+This directory contains a basic example of a requisition management system built with Laravel and Filament. It demonstrates how purchase requests can be submitted, approved, and tracked.
+
+## Features
+
+- **Request Submission**: Employees submit requisitions specifying vendor, item details, quantity, and required date.
+- **Approval Workflow**: Approvals are stored in a separate table and can be processed via Filament.
+- **Vendor Management**: Simple vendor directory.
+
+## Setup
+
+1. Install PHP dependencies via Composer.
+2. Run `php artisan migrate` to create the database tables.
+3. Install Filament admin panel and create a user with the `filament` role.
+
+Refer to the files inside the `app/` and `database/` directories for code examples.

--- a/laravel/app/Filament/Resources/ApprovalResource.php
+++ b/laravel/app/Filament/Resources/ApprovalResource.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ApprovalResource\Pages;
+use App\Models\Approval;
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Resources\Form;
+use Filament\Resources\Table;
+use Filament\Resources\Resource;
+
+class ApprovalResource extends Resource
+{
+    protected static ?string $model = Approval::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('requisition_id')
+                    ->relationship('requisition', 'id')
+                    ->required(),
+                Forms\Components\Select::make('approved_by')
+                    ->relationship('approver', 'name')
+                    ->required(),
+                Forms\Components\Select::make('status')
+                    ->options([
+                        'approved' => 'Approved',
+                        'rejected' => 'Rejected',
+                    ])
+                    ->required(),
+                Forms\Components\Textarea::make('remarks'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('requisition.id')->label('Requisition'),
+                Tables\Columns\TextColumn::make('approver.name')->label('Approver'),
+                Tables\Columns\TextColumn::make('status')->badge(),
+                Tables\Columns\TextColumn::make('created_at')->date(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListApprovals::route('/'),
+            'create' => Pages\CreateApproval::route('/create'),
+        ];
+    }
+}

--- a/laravel/app/Filament/Resources/ApprovalResource/Pages/CreateApproval.php
+++ b/laravel/app/Filament/Resources/ApprovalResource/Pages/CreateApproval.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ApprovalResource\Pages;
+
+use App\Filament\Resources\ApprovalResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateApproval extends CreateRecord
+{
+    protected static string $resource = ApprovalResource::class;
+}

--- a/laravel/app/Filament/Resources/ApprovalResource/Pages/ListApprovals.php
+++ b/laravel/app/Filament/Resources/ApprovalResource/Pages/ListApprovals.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\ApprovalResource\Pages;
+
+use App\Filament\Resources\ApprovalResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListApprovals extends ListRecords
+{
+    protected static string $resource = ApprovalResource::class;
+}

--- a/laravel/app/Filament/Resources/RequisitionResource.php
+++ b/laravel/app/Filament/Resources/RequisitionResource.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\RequisitionResource\Pages;
+use App\Models\Requisition;
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Resources\Form;
+use Filament\Resources\Table;
+use Filament\Resources\Resource;
+
+class RequisitionResource extends Resource
+{
+    protected static ?string $model = Requisition::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('vendor_id')
+                    ->relationship('vendor', 'name')
+                    ->searchable()
+                    ->required(),
+                Forms\Components\Textarea::make('item_description')
+                    ->required(),
+                Forms\Components\TextInput::make('quantity')
+                    ->numeric()
+                    ->default(1)
+                    ->required(),
+                Forms\Components\DatePicker::make('required_by'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('user.name')->label('Requested By'),
+                Tables\Columns\TextColumn::make('vendor.name'),
+                Tables\Columns\TextColumn::make('status')->badge(),
+                Tables\Columns\TextColumn::make('created_at')->date(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'approved' => 'Approved',
+                        'rejected' => 'Rejected',
+                    ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRequisitions::route('/'),
+            'create' => Pages\CreateRequisition::route('/create'),
+            'view' => Pages\ViewRequisition::route('/{record}'),
+        ];
+    }
+}

--- a/laravel/app/Filament/Resources/RequisitionResource/Pages/CreateRequisition.php
+++ b/laravel/app/Filament/Resources/RequisitionResource/Pages/CreateRequisition.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\RequisitionResource\Pages;
+
+use App\Filament\Resources\RequisitionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRequisition extends CreateRecord
+{
+    protected static string $resource = RequisitionResource::class;
+}

--- a/laravel/app/Filament/Resources/RequisitionResource/Pages/ListRequisitions.php
+++ b/laravel/app/Filament/Resources/RequisitionResource/Pages/ListRequisitions.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\RequisitionResource\Pages;
+
+use App\Filament\Resources\RequisitionResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRequisitions extends ListRecords
+{
+    protected static string $resource = RequisitionResource::class;
+}

--- a/laravel/app/Filament/Resources/RequisitionResource/Pages/ViewRequisition.php
+++ b/laravel/app/Filament/Resources/RequisitionResource/Pages/ViewRequisition.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\RequisitionResource\Pages;
+
+use App\Filament\Resources\RequisitionResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewRequisition extends ViewRecord
+{
+    protected static string $resource = RequisitionResource::class;
+}

--- a/laravel/app/Filament/Resources/VendorResource.php
+++ b/laravel/app/Filament/Resources/VendorResource.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\VendorResource\Pages;
+use App\Models\Vendor;
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Resources\Form;
+use Filament\Resources\Table;
+use Filament\Resources\Resource;
+
+class VendorResource extends Resource
+{
+    protected static ?string $model = Vendor::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required(),
+                Forms\Components\TextInput::make('contact_email'),
+                Forms\Components\TextInput::make('contact_phone'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')->sortable(),
+                Tables\Columns\TextColumn::make('name'),
+                Tables\Columns\TextColumn::make('contact_email'),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListVendors::route('/'),
+            'create' => Pages\CreateVendor::route('/create'),
+        ];
+    }
+}

--- a/laravel/app/Filament/Resources/VendorResource/Pages/CreateVendor.php
+++ b/laravel/app/Filament/Resources/VendorResource/Pages/CreateVendor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\VendorResource\Pages;
+
+use App\Filament\Resources\VendorResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateVendor extends CreateRecord
+{
+    protected static string $resource = VendorResource::class;
+}

--- a/laravel/app/Filament/Resources/VendorResource/Pages/ListVendors.php
+++ b/laravel/app/Filament/Resources/VendorResource/Pages/ListVendors.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\VendorResource\Pages;
+
+use App\Filament\Resources\VendorResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListVendors extends ListRecords
+{
+    protected static string $resource = VendorResource::class;
+}

--- a/laravel/app/Models/Approval.php
+++ b/laravel/app/Models/Approval.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Approval extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'requisition_id',
+        'approved_by',
+        'status',
+        'remarks'
+    ];
+
+    public function requisition(): BelongsTo
+    {
+        return $this->belongsTo(Requisition::class);
+    }
+
+    public function approver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by');
+    }
+}

--- a/laravel/app/Models/Requisition.php
+++ b/laravel/app/Models/Requisition.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Requisition extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'vendor_id',
+        'item_description',
+        'quantity',
+        'required_by',
+        'status'
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(Vendor::class);
+    }
+}

--- a/laravel/app/Models/Vendor.php
+++ b/laravel/app/Models/Vendor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Vendor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'contact_email',
+        'contact_phone'
+    ];
+}

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "example/requisition-system",
+  "type": "project",
+  "require": {
+    "php": "^8.1",
+    "laravel/framework": "^10.0",
+    "filament/filament": "^3.0",
+    "spatie/laravel-permission": "^6.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/"
+    }
+  }
+}

--- a/laravel/database/migrations/2024_01_01_000000_create_vendors_table.php
+++ b/laravel/database/migrations/2024_01_01_000000_create_vendors_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('vendors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('contact_email')->nullable();
+            $table->string('contact_phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vendors');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_000001_create_requisitions_table.php
+++ b/laravel/database/migrations/2024_01_01_000001_create_requisitions_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('requisitions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('vendor_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('item_description');
+            $table->integer('quantity')->default(1);
+            $table->date('required_by')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('requisitions');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_000002_create_approvals_table.php
+++ b/laravel/database/migrations/2024_01_01_000002_create_approvals_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('approvals', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('requisition_id')->constrained()->onDelete('cascade');
+            $table->foreignId('approved_by')->constrained('users')->onDelete('cascade');
+            $table->string('status');
+            $table->text('remarks')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('approvals');
+    }
+};

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+// Filament admin routes will be automatically registered


### PR DESCRIPTION
## Summary
- add skeleton PHP Laravel + Filament requisition management system with models, migrations and resources
- document backend in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684591827508832c9ed8c13c0ec8b718